### PR TITLE
Adapts skeleton meta-text description.

### DIFF
--- a/compile-time-programming/requires-clause.md
+++ b/compile-time-programming/requires-clause.md
@@ -1,3 +1,6 @@
 # Compile-time programming: requires-clause
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/compile-time-programming/requires-expressions.md
+++ b/compile-time-programming/requires-expressions.md
@@ -1,5 +1,8 @@
 # Module name: Requires Expressions
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 ## Overview
 
 <table>

--- a/functions/calling-functions.md
+++ b/functions/calling-functions.md
@@ -1,3 +1,6 @@
 # C++ functions: calling functions
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/functions/defaulted-parameters.md
+++ b/functions/defaulted-parameters.md
@@ -1,5 +1,7 @@
 # Functions: default argument
-_Skeleton instructions are typeset in italic text._
+
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
 
 ## Overview
 

--- a/functions/member-functions.md
+++ b/functions/member-functions.md
@@ -1,3 +1,6 @@
 # C++ functions: member functions
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/functions/user-defined-literals.md
+++ b/functions/user-defined-literals.md
@@ -1,6 +1,7 @@
 # Functions: user-defined literals
 
-_Skeleton instructions are typeset in italic text._
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
 
 ## Overview
 

--- a/meta-error-handling/static_assert.md
+++ b/meta-error-handling/static_assert.md
@@ -1,5 +1,7 @@
 # Meta-error handling: `static_assert`
-_Skeleton instructions are typeset in italic text._
+
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
 
 ## Overview
 

--- a/object-model/constant-objects.md
+++ b/object-model/constant-objects.md
@@ -1,3 +1,6 @@
 # C++ object model: constant objects
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/constructors.md
+++ b/object-model/constructors.md
@@ -1,3 +1,6 @@
 # C++ object model: constructor
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/copy-semantics.md
+++ b/object-model/copy-semantics.md
@@ -1,6 +1,7 @@
 # C++ object model: copy semantics
 
-_Skeleton instructions are typeset in italic text._
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
 
 ## Overview
 

--- a/object-model/declarations.md
+++ b/object-model/declarations.md
@@ -1,3 +1,6 @@
 # C++ object model: declarations
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/move-semantics.md
+++ b/object-model/move-semantics.md
@@ -1,3 +1,6 @@
 # C++ object model: move semantics
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/objects.md
+++ b/object-model/objects.md
@@ -1,3 +1,6 @@
 # C++ object model: objects
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/rule-of-five.md
+++ b/object-model/rule-of-five.md
@@ -1,3 +1,6 @@
 # C++ object model: rule of five
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/rule-of-zero.md
+++ b/object-model/rule-of-zero.md
@@ -1,3 +1,6 @@
 # C++ object model: rule of zero
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/special-member-functions.md
+++ b/object-model/special-member-functions.md
@@ -1,3 +1,6 @@
 # C++ object model: special member functions
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/object-model/types.md
+++ b/object-model/types.md
@@ -1,3 +1,6 @@
 # C++ object model: types
 
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
+
 This topic is currently under construction and will soon be filled with information :)

--- a/skeleton.md
+++ b/skeleton.md
@@ -1,5 +1,6 @@
 # Module name: topic name
-_Skeleton descriptions are typeset in italic text._
+_Skeleton descriptions are typeset in italic text,_
+_so please don't remove these descriptions when editing the topic._
 
 ## Overview
 

--- a/skeleton.md
+++ b/skeleton.md
@@ -1,5 +1,5 @@
 # Module name: topic name
-_Skeleton instructions are typeset in italic text._
+_Skeleton descriptions are typeset in italic text._
 
 ## Overview
 


### PR DESCRIPTION
Changes skeleton meta-text description wording from instructions to description. This should make it clearer for people that the italics descriptions should be kept in every topic.