### PR TITLE
Fix Build Issues for the "Definitions" Topic.

### DIFF
--- a/config/spellcheck/wordlist
+++ b/config/spellcheck/wordlist
@@ -1,17 +1,19 @@
-personal_ws-1.1 en 14
+personal_ws-1.1 en 18
+ABI
+boolean
+computable
 destructors
+IDEs
 invariants
+lawyering
 metaprogramming
 namespace
 namespaces
+ODR
 preprocessor
 redeclarations
-toolchains
+SFINAE
 toolchain
-boolean
-lawyering
-computable
+toolchains
 UDL
 UDLs
-IDEs
-SFINAE

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -121,6 +121,7 @@ contributors.md:
 # Establish Pandoc settings.
 ################################################################################
 
+PANDOC_OPTIONS += --verbose
 PANDOC_OPTIONS += --toc --toc-depth 3
 PANDOC_OPTIONS += --number-sections
 PANDOC_OPTIONS += --standalone
@@ -135,6 +136,12 @@ EPUB_CSS_FILE = css/default-pandoc.css
 
 #HTML_TEMPLATE = templates/bootstrap_menu.html
 HTML_TEMPLATE = $(TOP_DIR)/config/pandoc_templates/uikit.html
+
+#MAKEINFO_OPTIONS += --no-warn
+MAKEINFO_OPTIONS += --error-limit 1000000000000
+#MAKEINFO_OPTIONS += --verbose
+MAKEINFO_OPTIONS += --no-validate
+MAKEINFO_OPTIONS += --force
 
 ################################################################################
 # Rules for generating the document in various formats.
@@ -156,7 +163,7 @@ guidelines.docbook: $(GENERATED_MARKDOWN)
 	pandoc $(PANDOC_OPTIONS) --from $(INPUT_FORMAT) -o $@ main.gen.md
 
 guidelines_html: guidelines.texi
-	makeinfo --no-validate --force --html -o guidelines_html guidelines.texi
+	makeinfo $(MAKEINFO_OPTIONS) --html -o guidelines_html guidelines.texi
 
 guidelines.tex:
 	pandoc $(PANDOC_OPTIONS) --from $(INPUT_FORMAT) --to latex -o $@ main.gen.md


### PR DESCRIPTION
When building the teaching-guidelines document in multipage HTML
format, numerous multiply-defined labels arise due to apparent
limitations in the GNU Texinfo format, which is used as an
intermediary in the build process.  This commit adds a trivial
workaround to prevent this issue from causing the build to fail
due to this issue.
    
In addition, this commit also fixes some spellchecking failures
for the "definitions" topic.
